### PR TITLE
add fixes for path and callback error ignored

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`main.go` is the entrypoint for the `hubdeploy` daemon. Runtime configuration lives in `hubdeploy.yml`. Core application code is under `internal/`:
+
+- `internal/deploysrv/` contains server setup, config loading, handlers, and logging.
+- `internal/hookers/` contains webhook-specific integrations such as Docker Hub.
+
+Tests are colocated with the code they exercise, for example `internal/deploysrv/handlers_test.go` and `internal/hookers/dockerhub_test.go`. CI workflows live in `.github/workflows/`.
+
+## Build, Test, and Development Commands
+- `go build ./...` builds all packages and matches the main CI build step.
+- `go test ./...` runs the full test suite across the module.
+- `go test -v ./...` shows subtest names and is the exact form used in GitHub Actions.
+- `go run . -c hubdeploy.yml -v` starts the service with the local config file and verbose logging.
+
+Use Go 1.22 to match [`go.mod`](/Users/rustam/wp/_github/hubdeploy/go.mod).
+
+## Coding Style & Naming Conventions
+Follow standard Go formatting and keep code `gofmt`-clean. Use tabs for indentation as produced by `gofmt`, lowercase package names, and mixedCaps for exported and unexported identifiers. Keep package internals in `internal/`, and prefer small focused files grouped by concern such as `config.go`, `handlers.go`, and `log.go`.
+
+When adding flags, config fields, or webhook types, keep naming consistent with existing code and YAML keys.
+
+## Testing Guidelines
+Write table-driven tests where practical; the existing suite uses that style heavily. Keep test files next to implementation and name tests with the Go convention `TestXxx`. Use `github.com/stretchr/testify/assert` only where it improves readability; plain `testing` checks are also common here.
+
+Run `go test ./...` before opening a PR. Add or update tests for any change to request handling, config parsing, or webhook registration.
+
+## Commit & Pull Request Guidelines
+Recent commits use short, imperative subjects such as `update deps`, `code cleanup`, and `run as a daemon`. Keep commit titles concise and descriptive.
+
+PRs should include a brief summary, the reason for the change, and test results from `go test ./...`. Link related issues when applicable. Include config or API examples when behavior changes affect webhook payloads or server startup.

--- a/internal/deploysrv/deploysrv.go
+++ b/internal/deploysrv/deploysrv.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -134,8 +135,9 @@ func New(c Config, opts ...Option) (*Server, error) {
 	return s, nil
 }
 
-// Register allows to register custom Hookers.  Must be called after New and
-// before ListenAndServe.
+// Register allows to register custom Hookers. It must be called before New,
+// because config validation resolves deployment types from the global
+// registry during server construction.
 func Register(h Hooker) error {
 	if h == nil {
 		return errors.New("programming error:  hooker is empty")
@@ -149,10 +151,12 @@ func (s *Server) resultsURL() string {
 	if s.url == "" || s.resultsDir == "" {
 		return ""
 	}
-	if s.url[len(s.url)-1] != '/' {
-		s.url = s.url + "/"
+	base := strings.TrimRight(s.url, "/")
+	prefix := path.Clean("/" + strings.TrimSpace(s.prefix))
+	if prefix == "." || prefix == "/" {
+		prefix = ""
 	}
-	return s.url + results + "/"
+	return base + prefix + "/" + results + "/"
 
 }
 
@@ -240,14 +244,16 @@ func (s *Server) processor(results <-chan result) {
 			continue
 		}
 
-		dp.Callback(CallbackData{
+		if err := dp.Callback(CallbackData{
 			ID:          res.id,
 			CallbackURL: res.url,
 			Description: ifErrNotNil(res.err, "deployed with error", "deployed OK"),
 			Context:     "Continuous integration by github.com/rusq/hubdeploy",
 			Error:       res.err,
 			ResultsURL:  s.resultsURL() + res.id.String() + resultExt,
-		})
+		}); err != nil {
+			dlog.Printf("%s> callback failed for %q: %v", res.id, res.url, err)
+		}
 	}
 }
 

--- a/internal/deploysrv/deploysrv_test.go
+++ b/internal/deploysrv/deploysrv_test.go
@@ -1,8 +1,50 @@
 package deploysrv
 
-import "testing"
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rusq/dlog"
+)
+
+type stubHooker struct {
+	registerErr error
+	callbackErr error
+	callbacks   chan CallbackData
+}
+
+func (s *stubHooker) Register(Deployment) error { return s.registerErr }
+func (s *stubHooker) Handler(chan<- Job) http.HandlerFunc {
+	panic("not used in tests")
+}
+func (s *stubHooker) Callback(data CallbackData) error {
+	if s.callbacks != nil {
+		s.callbacks <- data
+	}
+	return s.callbackErr
+}
+func (s *stubHooker) Type() string { return "stub" }
+
+func withDeploymentTypes(t *testing.T) {
+	t.Helper()
+	old := deploymentTypes
+	deploymentTypes = make(map[string]Hooker)
+	t.Cleanup(func() {
+		deploymentTypes = old
+	})
+}
 
 func TestServer_resultsURL(t *testing.T) {
+	withDeploymentTypes(t)
+
 	type fields struct {
 		cert       string
 		privkey    string
@@ -17,7 +59,11 @@ func TestServer_resultsURL(t *testing.T) {
 		fields fields
 		want   string
 	}{
-		{"ok", fields{resultsDir: "/res/", url: "https://endless.lol"}, "https://endless.lol/" + results + "/"},
+		{"root prefix", fields{resultsDir: "/res/", url: "https://endless.lol"}, "https://endless.lol/" + results + "/"},
+		{"non-root prefix", fields{resultsDir: "/res/", url: "https://endless.lol", prefix: "/api"}, "https://endless.lol/api/" + results + "/"},
+		{"prefix trailing slash", fields{resultsDir: "/res/", url: "https://endless.lol/", prefix: "/api/"}, "https://endless.lol/api/" + results + "/"},
+		{"empty server url", fields{resultsDir: "/res/"}, ""},
+		{"empty results dir", fields{url: "https://endless.lol", prefix: "/api"}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -35,4 +81,88 @@ func TestServer_resultsURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServer_processor_logsCallbackFailures(t *testing.T) {
+	withDeploymentTypes(t)
+
+	hook := &stubHooker{
+		callbackErr: errors.New("callback down"),
+		callbacks:   make(chan CallbackData, 1),
+	}
+	deploymentTypes[hook.Type()] = hook
+
+	var buf bytes.Buffer
+	dlog.SetOutput(&buf)
+	t.Cleanup(func() {
+		dlog.SetOutput(os.Stderr)
+	})
+
+	s := &Server{
+		resultsDir: t.TempDir(),
+		url:        "https://example.test",
+		prefix:     "/api",
+	}
+
+	resultsCh := make(chan result)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.processor(resultsCh)
+	}()
+
+	id := uuid.Must(uuid.NewUUID())
+	resultsCh <- result{id: id, typ: hook.Type(), url: "https://callback.test", output: []byte("ok")}
+
+	select {
+	case cb := <-hook.callbacks:
+		wantURL := "https://example.test/api/results/" + id.String() + resultExt
+		if cb.ResultsURL != wantURL {
+			t.Fatalf("CallbackData.ResultsURL = %q, want %q", cb.ResultsURL, wantURL)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("processor did not invoke callback")
+	}
+
+	close(resultsCh)
+	wg.Wait()
+
+	if !strings.Contains(buf.String(), "callback failed") {
+		t.Fatalf("expected callback failure to be logged, got %q", buf.String())
+	}
+}
+
+func TestNew_requiresRegisteredHookersBeforeValidation(t *testing.T) {
+	withDeploymentTypes(t)
+
+	workdir := t.TempDir()
+	newConfig := func() Config {
+		return Config{
+			ResultsDir: filepath.Join(t.TempDir(), "results"),
+			Deployments: []Deployment{
+				{
+					Type:    "stub",
+					Workdir: workdir,
+					Command: []string{"echo", "ok"},
+					Payload: map[string]any{"repo": "demo"},
+				},
+			},
+		}
+	}
+
+	if _, err := New(newConfig()); err == nil {
+		t.Fatal("New() error = nil, want unregistered deployment type failure")
+	}
+
+	if err := Register(&stubHooker{}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	srv, err := New(newConfig())
+	if err != nil {
+		t.Fatalf("New() after Register() error = %v", err)
+	}
+	close(srv.jobs)
+	close(srv.results)
 }

--- a/internal/hookers/dockerhub.go
+++ b/internal/hookers/dockerhub.go
@@ -181,6 +181,7 @@ func (d *DockerHub) Callback(data deploysrv.CallbackData) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("invalid status code: %d", resp.StatusCode)
 	}

--- a/internal/hookers/dockerhub_test.go
+++ b/internal/hookers/dockerhub_test.go
@@ -1,9 +1,13 @@
 package hookers
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/goccy/go-yaml"
+	"github.com/google/uuid"
 
 	"github.com/rusq/hubdeploy/internal/deploysrv"
 )
@@ -47,6 +51,53 @@ func TestDockerHub_Register(t *testing.T) {
 			}
 			if err := d.Register(tt.args.dep); (err != nil) != tt.wantErr {
 				t.Errorf("DockerHub.Register() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDockerHub_Callback(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "ok", statusCode: http.StatusOK},
+		{name: "bad status", statusCode: http.StatusBadGateway, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got callback
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+					t.Fatalf("decode callback body: %v", err)
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			d := &DockerHub{}
+			err := d.Callback(deploysrv.CallbackData{
+				ID:          uuid.Must(uuid.NewUUID()),
+				CallbackURL: srv.URL,
+				Description: "deployed OK",
+				Context:     "test context",
+				ResultsURL:  "https://example.test/results/id.txt",
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Callback() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got.Context != "test context" {
+				t.Fatalf("callback context = %q, want %q", got.Context, "test context")
+			}
+			if got.TargetURL != "https://example.test/results/id.txt" {
+				t.Fatalf("callback target_url = %q, want %q", got.TargetURL, "https://example.test/results/id.txt")
+			}
+			if got.State != ssuccess {
+				t.Fatalf("callback state = %q, want %q", got.State, ssuccess)
 			}
 		})
 	}


### PR DESCRIPTION
 Findings

  1. High: callback failures are silently dropped, so upstream systems can be told nothing even when deployment finished and the status post failed. In internal/deploysrv/deploysrv.go:243,
  dp.Callback(...) is called and its error is ignored. Any network error, bad callback URL, or non-200 response from Docker Hub disappears from logs and control flow, which makes successful local
  execution look healthy while the webhook source never receives status.
  2. High: result callback URLs are wrong whenever a non-root prefix is configured. internal/deploysrv/deploysrv.go:147 builds server_url + "results/", but the HTTP routes are registered under
  path.Join(s.prefix, results)+"/" at internal/deploysrv/deploysrv.go:194. If the service runs with -prefix /api, callbacks still point to /results/... instead of /api/results/..., so external status
  links break.
  3. Medium: the Docker Hub callback response body is never closed, which can leak connections/file descriptors under repeated webhook traffic. internal/hookers/dockerhub.go:180 performs http.Post,
  then reads resp.Body later, but there is no defer resp.Body.Close(). On a long-running daemon this accumulates.
  4. Medium: the public registration contract is backwards relative to the implementation. internal/deploysrv/deploysrv.go:137 says Register must be called after New, but New validates deployments
  against the global deploymentTypes map at internal/deploysrv/config.go:75. If another caller follows the documented order, all configured deployments are marked disabled as unregistered.